### PR TITLE
fix: トレーダー名のURL形式をslugに変更

### DIFF
--- a/app/components/TaskTreeView.tsx
+++ b/app/components/TaskTreeView.tsx
@@ -18,6 +18,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css';
 import { Task } from '../types/task';
 import TaskDetailModal from './TaskDetailModal';
+import { traderNameToSlug } from '../lib/traderSlug';
 
 interface TaskTreeViewProps {
   tasks: Task[];
@@ -350,7 +351,8 @@ function TaskTreeViewInner({ tasks, allTasks, traderName }: TaskTreeViewProps) {
           onHover: setHoveredTaskId,
           onNavigateToTrader: (traderName: string, taskId: string) => {
             const basePath = process.env.NODE_ENV === 'production' ? '/tarkov-helper' : '';
-            window.location.href = `${basePath}/traders/${encodeURIComponent(traderName)}?taskId=${taskId}`;
+            const traderSlug = traderNameToSlug(traderName);
+            window.location.href = `${basePath}/traders/${traderSlug}?taskId=${taskId}`;
           },
           onClick: () => setSelectedTask(task),
         } as TaskNodeData,
@@ -534,7 +536,8 @@ function TaskTreeViewInner({ tasks, allTasks, traderName }: TaskTreeViewProps) {
           isLocked={selectedTask.taskRequirements.some(req => !completedTasks.has(req.task.id))}
           onNavigateToTrader={(traderName: string, taskId: string) => {
             const basePath = process.env.NODE_ENV === 'production' ? '/tarkov-helper' : '';
-            window.location.href = `${basePath}/traders/${encodeURIComponent(traderName)}?taskId=${taskId}`;
+            const traderSlug = traderNameToSlug(traderName);
+            window.location.href = `${basePath}/traders/${traderSlug}?taskId=${taskId}`;
           }}
         />
       )}

--- a/app/lib/taskData.ts
+++ b/app/lib/taskData.ts
@@ -9,7 +9,5 @@ export function getTaskData(): TaskData {
 }
 
 export function getUniqueTraderNames(taskData: TaskData): string[] {
-  return Array.from(
-    new Set(taskData.tasks.map(task => task.trader.name))
-  );
+  return Array.from(new Set(taskData.tasks.map((task) => task.trader.name)));
 }

--- a/app/lib/traderSlug.ts
+++ b/app/lib/traderSlug.ts
@@ -1,0 +1,11 @@
+// トレーダー名をURL-safeなslugに変換（クライアント・サーバー両方で使用可能）
+
+// トレーダー名をURL-safeなslugに変換
+export function traderNameToSlug(traderName: string): string {
+  return traderName.replace(/\s+/g, '-');
+}
+
+// slugをトレーダー名に戻す
+export function slugToTraderName(slug: string): string {
+  return slug.replace(/-/g, ' ');
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import TraderCardProgress from './components/TraderCardProgress';
 import { getTaskData } from './lib/taskData';
+import { traderNameToSlug } from './lib/traderSlug';
 
 export default function Home() {
   // タスクデータを読み込み
@@ -39,7 +40,7 @@ export default function Home() {
               return (
                 <Link
                   key={traderName}
-                  href={`/traders/${encodeURIComponent(traderName)}`}
+                  href={`/traders/${traderNameToSlug(traderName)}`}
                   className="bg-gray-800 rounded-lg p-6 hover:bg-gray-750 transition-all hover:scale-105 hover:shadow-xl border-2 border-transparent hover:border-yellow-400"
                 >
                   <div className="flex items-center gap-3 mb-4">

--- a/app/traders/[trader]/page.tsx
+++ b/app/traders/[trader]/page.tsx
@@ -3,6 +3,7 @@ import TaskTreeView from '@/app/components/TaskTreeView';
 import ProgressStats from '@/app/components/ProgressStats';
 import TraderTaskSync from '@/app/components/TraderTaskSync';
 import { getTaskData, getUniqueTraderNames } from '@/app/lib/taskData';
+import { traderNameToSlug, slugToTraderName } from '@/app/lib/traderSlug';
 
 interface PageProps {
   params: Promise<{
@@ -14,15 +15,15 @@ export async function generateStaticParams() {
   const taskData = getTaskData();
   const traders = getUniqueTraderNames(taskData);
 
-  // 各トレーダーのパラメータを返す
+  // 各トレーダーのパラメータを返す（スペースをハイフンに変換）
   return traders.map(traderName => ({
-    trader: encodeURIComponent(traderName),
+    trader: traderNameToSlug(traderName),
   }));
 }
 
 export default async function TraderPage({ params }: PageProps) {
-  const { trader: encodedTrader } = await params;
-  const traderName = decodeURIComponent(encodedTrader);
+  const { trader: traderSlug } = await params;
+  const traderName = slugToTraderName(traderSlug);
 
   // タスクデータを読み込み
   const taskData = getTaskData();


### PR DESCRIPTION
- スペースを含むトレーダー名(BTR Driver)が404になる問題を修正
- トレーダー名のスペースをハイフンに変換してURL-safe化
- traderSlug.ts を新規作成（クライアント/サーバー共用）
- BTR Driver → BTR-Driver に変換
- GitHub Pagesでスペースを含むURLが正しく処理されるように改善